### PR TITLE
Add unit conversion functions

### DIFF
--- a/src/spectroscopy_bluesky/common/quantity_conversion.py
+++ b/src/spectroscopy_bluesky/common/quantity_conversion.py
@@ -69,7 +69,7 @@ def crystal_spacing(lattice_parameter: float, miller_indices: list[int]) -> floa
     """
     if len(miller_indices) != 3:
         raise Exception(
-            "Need 3 values for the Miller indices to calculate lattice spacing!"
+            "Need 3 values for the Miller indices to calculate lattice spacing!",
         )
 
     denom = float(sum([i * i for i in miller_indices]))
@@ -77,7 +77,8 @@ def crystal_spacing(lattice_parameter: float, miller_indices: list[int]) -> floa
 
 
 def bragg_angle_to_wavelength(
-    lattice_spacing: float, angle_deg: ndarray_or_number
+    lattice_spacing: float,
+    angle_deg: ndarray_or_number,
 ) -> NDArray:
     """Convert from Bragg angle (degrees) to wavelength (Angstroms)
 
@@ -92,7 +93,9 @@ def bragg_angle_to_wavelength(
 
 
 def energy_to_bragg_angle(
-    lattice_spacing: float, energy_ev: ndarray_or_number, return_radians=False
+    lattice_spacing: float,
+    energy_ev: ndarray_or_number,
+    return_radians=False,
 ) -> NDArray:
     """Convert photon energy (eV) to Bragg angle
     (using :func:`ev_to_wavelength` and :func:`wavelength_to_bragg_angle`)
@@ -110,7 +113,8 @@ def energy_to_bragg_angle(
 
 
 def bragg_angle_to_energy(
-    lattice_spacing: float, bragg_angle_degrees: ndarray_or_number
+    lattice_spacing: float,
+    bragg_angle_degrees: ndarray_or_number,
 ) -> ndarray_or_number:
     """Convert Bragg angle (degrees) to energy (ev)
 
@@ -148,7 +152,7 @@ def wavelength_to_bragg_angle(
     if val > 1:
         raise Exception(
             f"Wavelength {wavelength_angstroms} Angstroms is too large for "
-            "lattice spacing {lattice_spacing/angstrom} Angstroms!"
+            "lattice spacing {lattice_spacing/angstrom} Angstroms!",
         )
 
     theta = np.asin(val)

--- a/tests/common/test_quantity_conversion.py
+++ b/tests/common/test_quantity_conversion.py
@@ -58,9 +58,9 @@ def test_ev_wavelength(energy, expected_wavelength):
 def test_bragg_energy(angle, expected_energy):
     energy = bragg_angle_to_energy(si_311_lattice_spacing, angle)
     assert energy == pytest.approx(expected_energy, 1e-6)
-    assert energy_to_bragg_angle(
-        si_311_lattice_spacing, energy
-        ) == pytest.approx(angle, 1e-8)
+    assert energy_to_bragg_angle(si_311_lattice_spacing, energy) == pytest.approx(
+        angle, 1e-8
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change adds various functions and constants to help with conversion between quantities in different units commonly used in spectroscopy : 
* photon energy (eV) - wavelength (Angstroms)
* photon energy (eV) - wavelvector (inverse Angstroms)
* Bragg angle - wavelength or energy
* Constants for Si 311 and Si 111 lattice spacing  (used for Bragg equation)

Additionally there is a function to calculate the lattice spacing from lattice parameter and Miller indices.
Physical constants from scipy.constants (i.e. values from CODATA 2022) are used in the various equations to avoid relying on 'magic numbers' to convert between different quantities.
