### PR TITLE
Debug panda scan

### DIFF
--- a/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
+++ b/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
@@ -202,7 +202,7 @@ def prepare_panda(
     )
 
     def inner_plan():
-        yield from bps.prepare(panda, trigger_info)
+        yield from bps.prepare(panda, trigger_info, wait=True)
 
     return inner_plan
 
@@ -359,7 +359,6 @@ def seq_table_uniform_scan(
     readable_pvs: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
-
     capture_positions = np.arange(start, stop + 0.5 * stepsize, stepsize)
 
     # setup a second seq table for 'spectrum based' triggering :
@@ -415,7 +414,6 @@ def seq_table_position_scan(
     panda_dict: dict[HDFPanda, list[Callable[[], MsgGenerator]]] | None = None,
     **kwargs: Any,
 ) -> MsgGenerator:
-
     time_per_traj_point = time_per_sweep / num_trajectory_points
 
     print(
@@ -495,7 +493,6 @@ def debug_scan(
     number_of_sweeps: int = 4,
     panda_dict: dict[HDFPanda, list[Callable[[], MsgGenerator]]] | None = None,
 ) -> MsgGenerator:
-
     time_per_traj_point = time_per_sweep / num_trajectory_points
     capture_positions = np.arange(start, stop + 0.5 * stepsize, stepsize)
 

--- a/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
+++ b/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
@@ -179,6 +179,34 @@ def prepare_seq_table(
     return inner_plan
 
 
+def prepare_panda(
+    panda: HDFPanda,
+) -> Callable[[], MsgGenerator]:
+    """Return a function that can be used to prepare and arm (kickoff) a
+    panda without a sequencer table. Used mainly for the debug PandA
+
+    Args:
+        panda (HDFPanda): Panda object to be operated on
+
+    Returns:
+        Callable[[], MsgGenerator]: _description_
+
+    Yields:
+        Iterator[Callable[[], MsgGenerator]]: _description_
+    """
+    trigger_info = TriggerInfo(
+        number_of_events=0,
+        trigger=DetectorTrigger.EXTERNAL_LEVEL,
+        livetime=1e-5,
+        deadtime=1e-5,
+    )
+
+    def inner_plan():
+        yield from bps.prepare(panda, trigger_info)
+
+    return inner_plan
+
+
 def seq_table_non_linear(
     ei: float,
     ef: float,
@@ -453,6 +481,67 @@ def seq_table_position_scan(
         }
     )
     yield from seq_table_scan(spec, panda_dict, motor=motor, **kwargs)
+
+
+def debug_scan(
+    start: float,
+    stop: float,
+    stepsize: float,
+    time_per_sweep: float,
+    motor: Motor,
+    panda_seq: HDFPanda,
+    panda_debug: HDFPanda,
+    num_trajectory_points: int = 10,
+    number_of_sweeps: int = 4,
+    panda_dict: dict[HDFPanda, list[Callable[[], MsgGenerator]]] | None = None,
+) -> MsgGenerator:
+
+    time_per_traj_point = time_per_sweep / num_trajectory_points
+    capture_positions = np.arange(start, stop + 0.5 * stepsize, stepsize)
+
+    print(
+        f"Num trajectorypoints : {num_trajectory_points}, "
+        f"time per traj point : {time_per_traj_point} "
+        f"Num capture positions: {len(capture_positions)}"
+    )
+
+    # Prepare motor info using trajectory scanning
+    spec = Fly(
+        time_per_traj_point
+        @ (number_of_sweeps * ~Line(motor, start, stop, num_trajectory_points))
+    )
+
+    # add points to capture positions on the reverse sweep
+    if number_of_sweeps > 1:
+        num_captures = capture_positions.size
+        positions = np.zeros(2 * num_captures)
+        positions[0:num_captures] = capture_positions
+        positions[num_captures : num_captures * 2] = np.flip(capture_positions)
+    else:
+        positions = capture_positions
+
+    num_seqtable_repeats = 1
+    if number_of_sweeps > 1:
+        num_seqtable_repeats = mt.ceil(number_of_sweeps / 2)
+
+    # Sequence table has position triggers for one back-and-forth sweep.
+    # Use multiple repetitions of seq table to capture subsequent sweeps.
+    seqTable_builder = SeqTableBuilder()
+    seqTable_builder.convert_to_encoder = get_encoder_counts
+    seqTable_builder.add_positions(positions, time1=1, outa1=True, time2=1, outa2=False)
+    # initialise if nothing has been passed in
+    if panda_dict is None:
+        panda_dict = {}
+
+    prepare_position_seqtable = prepare_seq_table(
+        panda_seq, seqTable_builder.get_seq_table(), 1, num_seqtable_repeats
+    )
+    # append position sequence table setup to panda entry (make empty list first
+    # if not already present).
+    panda_dict.setdefault(panda_seq, []).append(prepare_position_seqtable)
+
+    panda_dict[panda_debug] = [prepare_panda(panda=panda_debug)]
+    yield from seq_table_scan(spec, panda_dict, motor=motor)
 
 
 def seq_table_scan(

--- a/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
+++ b/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
@@ -443,7 +443,12 @@ def seq_table_position_scan(
     )
     # append position sequence table setup to panda entry (make empty list first
     # if not already present).
-    panda_dict.setdefault(panda, []).append(prepare_position_seqtable)
+    panda_dict.setdefault(panda, [prepare_position_seqtable, prepare_panda_data(panda)])
+
+    if "panda_debug" in kwargs.keys():
+        panda_dict[kwargs["panda_debug"]] = [
+            prepare_panda_data(panda=kwargs["panda_debug"])
+        ]
 
     if kwargs.get("scan_params_dict") is None:
         kwargs["scan_params_dict"] = {}

--- a/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
+++ b/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
@@ -131,7 +131,6 @@ def prepare_seq_table(
     seq_table_number: int = 1,
     num_repeats: int = 1,
     prescale_as_us: float = 1,
-    prepare_panda: bool = True,
 ) -> Callable[[], MsgGenerator]:
     """Return a function that can be used to prepare and arm (kickoff) a
     panda sequence table
@@ -143,8 +142,6 @@ def prepare_seq_table(
                                 Defaults to 1.
         num_repeats (int, optional): Number of repeats of sequence table. Defaults to 1.
         prescale_as_us (float, optional): _description_. Defaults to 1.
-        prepare_panda (bool, optional): If true, add calls to also arm the panda as well
-        as the sequence table. Defaults to True.
 
     Returns:
         Callable[[], MsgGenerator]: _description_
@@ -161,16 +158,7 @@ def prepare_seq_table(
         StaticSeqTableTriggerLogic(panda.seq[seq_table_number])
     )
 
-    trigger_info = TriggerInfo(
-        number_of_events=len(seq_table),
-        trigger=DetectorTrigger.EXTERNAL_LEVEL,
-        livetime=1e-5,
-        deadtime=1e-5,
-    )
-
     def inner_plan():
-        if prepare_panda:
-            yield from bps.prepare(panda, trigger_info)
         yield from bps.prepare(seqtable_flyer, seq_table_info, wait=True)
 
         yield from bps.kickoff(seqtable_flyer)
@@ -179,11 +167,11 @@ def prepare_seq_table(
     return inner_plan
 
 
-def prepare_panda(
+def prepare_panda_data(
     panda: HDFPanda,
 ) -> Callable[[], MsgGenerator]:
     """Return a function that can be used to prepare and arm (kickoff) a
-    panda without a sequencer table. Used mainly for the debug PandA
+    panda data.
 
     Args:
         panda (HDFPanda): Panda object to be operated on
@@ -318,7 +306,7 @@ def seq_table_two_panda_scan(
         prepare_triggers_seqtable = prepare_seq_table(
             panda2, seq_table, 1, num_seqtable_repeats
         )
-        panda_dict[panda2] = [prepare_triggers_seqtable]
+        panda_dict[panda2] = [prepare_triggers_seqtable, prepare_panda_data(panda2)]
 
     scan_params_dict = {
         "scan_name": "seq_table_two_panda_scan",
@@ -371,10 +359,8 @@ def seq_table_uniform_scan(
             .get_seq_table()
         )
 
-        prepare_triggers_seqtable = prepare_seq_table(
-            panda, seq_table, 2, prepare_panda=False
-        )
-        panda_dict[panda] = [prepare_triggers_seqtable]
+        prepare_triggers_seqtable = prepare_seq_table(panda, seq_table, 2)
+        panda_dict[panda] = [prepare_triggers_seqtable, prepare_panda_data(panda)]
 
     scan_params_dict = {
         "scan_name": "seq_table_uniform_scan",
@@ -533,11 +519,8 @@ def debug_scan(
     prepare_position_seqtable = prepare_seq_table(
         panda_seq, seqTable_builder.get_seq_table(), 1, num_seqtable_repeats
     )
-    # append position sequence table setup to panda entry (make empty list first
-    # if not already present).
-    panda_dict.setdefault(panda_seq, []).append(prepare_position_seqtable)
-
-    panda_dict[panda_debug] = [prepare_panda(panda=panda_debug)]
+    panda_dict[panda_seq] = [prepare_position_seqtable, prepare_panda_data(panda_seq)]
+    panda_dict[panda_debug] = [prepare_panda_data(panda=panda_debug)]
     yield from seq_table_scan(spec, panda_dict, motor=motor)
 
 

--- a/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
+++ b/src/spectroscopy_bluesky/p51/plans/seq_table_scans.py
@@ -472,63 +472,6 @@ def seq_table_position_scan(
     yield from seq_table_scan(spec, panda_dict, motor=motor, **kwargs)
 
 
-def debug_scan(
-    start: float,
-    stop: float,
-    stepsize: float,
-    time_per_sweep: float,
-    motor: Motor,
-    panda_seq: HDFPanda,
-    panda_debug: HDFPanda,
-    num_trajectory_points: int = 10,
-    number_of_sweeps: int = 4,
-    panda_dict: dict[HDFPanda, list[Callable[[], MsgGenerator]]] | None = None,
-) -> MsgGenerator:
-    time_per_traj_point = time_per_sweep / num_trajectory_points
-    capture_positions = np.arange(start, stop + 0.5 * stepsize, stepsize)
-
-    print(
-        f"Num trajectorypoints : {num_trajectory_points}, "
-        f"time per traj point : {time_per_traj_point} "
-        f"Num capture positions: {len(capture_positions)}"
-    )
-
-    # Prepare motor info using trajectory scanning
-    spec = Fly(
-        time_per_traj_point
-        @ (number_of_sweeps * ~Line(motor, start, stop, num_trajectory_points))
-    )
-
-    # add points to capture positions on the reverse sweep
-    if number_of_sweeps > 1:
-        num_captures = capture_positions.size
-        positions = np.zeros(2 * num_captures)
-        positions[0:num_captures] = capture_positions
-        positions[num_captures : num_captures * 2] = np.flip(capture_positions)
-    else:
-        positions = capture_positions
-
-    num_seqtable_repeats = 1
-    if number_of_sweeps > 1:
-        num_seqtable_repeats = mt.ceil(number_of_sweeps / 2)
-
-    # Sequence table has position triggers for one back-and-forth sweep.
-    # Use multiple repetitions of seq table to capture subsequent sweeps.
-    seqTable_builder = SeqTableBuilder()
-    seqTable_builder.convert_to_encoder = get_encoder_counts
-    seqTable_builder.add_positions(positions, time1=1, outa1=True, time2=1, outa2=False)
-    # initialise if nothing has been passed in
-    if panda_dict is None:
-        panda_dict = {}
-
-    prepare_position_seqtable = prepare_seq_table(
-        panda_seq, seqTable_builder.get_seq_table(), 1, num_seqtable_repeats
-    )
-    panda_dict[panda_seq] = [prepare_position_seqtable, prepare_panda_data(panda_seq)]
-    panda_dict[panda_debug] = [prepare_panda_data(panda=panda_debug)]
-    yield from seq_table_scan(spec, panda_dict, motor=motor)
-
-
 def seq_table_scan(
     scan_spec: Fly,
     panda_dict: dict[


### PR DESCRIPTION
Add a "trajectory debug" scan.

For this scan we have two PandAs one doing position compare triggering based on the set trajectory and another one that's responsible for capturing the encoder data at a faster rate.

One major change was the re-factoring of the `prepare_seq_table` function. I split it's logic in two different functions. One will be responsible for `prepare` and `kickoff` of the sequencer table while another method handles those stages but only for the data logic.